### PR TITLE
Dokka output directory change

### DIFF
--- a/vgsshow/build.gradle
+++ b/vgsshow/build.gradle
@@ -61,3 +61,7 @@ dependencies {
 }
 
 apply from: rootProject.file('release-bintray.gradle')
+
+tasks.named("dokkaJavadoc") {
+    outputDirectory.set(rootProject.file('docs'))
+}


### PR DESCRIPTION
## [ANDROIDSDK-55](https://verygoodsecurity.atlassian.net/browse/ANDROIDSDK-55)

## Description of changes
Set 'docs' as the default directory for the dokkaJavadoc task