### PR TITLE
Bump compile and target SDK version to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.demoshow'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.verygoodsecurity.demoshow"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ rootProject.name = "vgs-show-android"
 dependencyResolutionManagement {
     versionCatalogs {
         gradlePlugins {
-            library('tools', 'com.android.tools.build:gradle:8.1.1')
+            library('tools', 'com.android.tools.build:gradle:8.1.2')
             library('kotlin', 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10')
             library('maven-publish', 'com.vanniktech:gradle-maven-publish-plugin:0.25.3')
             library('dokka', 'org.jetbrains.dokka:dokka-gradle-plugin:1.9.0')
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
         }
         libs {
             library('androidx-appcompat', 'androidx.appcompat:appcompat:1.6.1')
-            library('androidx-core-ktx', 'androidx.core:core-ktx:1.10.1')
+            library('androidx-core-ktx', 'androidx.core:core-ktx:1.12.0')
             library('androidx-constraintlayout', 'androidx.constraintlayout:constraintlayout:2.1.4')
             library('okHttp', 'com.squareup.okhttp3:okhttp:4.11.0')
             library('pdf-viewer', 'com.verygoodsecurity:android-pdf-viewer:1.0.0')

--- a/vgsshow/build.gradle
+++ b/vgsshow/build.gradle
@@ -10,11 +10,11 @@ plugins {
 
 android {
     namespace 'com.verygoodsecurity.vgsshow'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
 


### PR DESCRIPTION
## Feature [CSDK-744]

## Description of changes
- Bump target/compile sdk version to 34
- Bump gradle version
- Bump ktx version
- Make sure nothing is broken and fully support SDK version 34

[CSDK-744]: https://verygoodsecurity.atlassian.net/browse/CSDK-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ