### PR TITLE
Fix: Remove redundant `FileProvider` declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Table of contents
 
 | Dependency | Version |
 | :--- |:-------:|
-| Min SDK |   19    |
-| Target SDK |   33    |
-| org.jetbrains.kotlin:kotlin-gradle-plugin |  1.9.0  |
+| Min SDK |   21    |
+| Target SDK |   34    |
+| org.jetbrains.kotlin:kotlin-gradle-plugin |  1.9.22 |
 | androidx.appcompat:appcompat |  1.6.1  |
-| com.squareup.okhttp3:okhttp | 4.11.0  |
+| com.squareup.okhttp3:okhttp | 4.12.0  |
 
 ## Structure
 * **VGSShow SDK** - provides an API for interacting with the VGS Vault

--- a/vgsshow/src/main/AndroidManifest.xml
+++ b/vgsshow/src/main/AndroidManifest.xml
@@ -2,18 +2,4 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <application>
-
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="com.verygoodsecurity.vgsshow.provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
-    </application>
 </manifest>

--- a/vgsshow/src/main/res/xml/file_paths.xml
+++ b/vgsshow/src/main/res/xml/file_paths.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-
-    <files-path
-        name="vgs"
-        path="vgs/" />
-</paths>


### PR DESCRIPTION
## Feature [CSL3-2170]

## Description of changes
 - Remove `FileProvider` declaration


[CSL3-2170]: https://verygoodsecurity.atlassian.net/browse/CSL3-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ